### PR TITLE
Random nonce

### DIFF
--- a/source/suite/get_started/authentication_php.rst
+++ b/source/suite/get_started/authentication_php.rst
@@ -28,7 +28,7 @@ PHP
     *   an ISO 8601 date string like '2010-12-31T15:30:59+00:00' or '2010-12-31T15:30:59Z'
     * passwordDigest looks sg like 'MDBhOTMwZGE0OTMxMjJlODAyNmE1ZWJhNTdmOTkxOWU4YzNjNWZkMw=='
     */
-   $nonce = 'd36e316282959a9ed4c89851497a717f';
+   $nonce = base64_encode(openssl_random_pseudo_bytes(16));
    $timestamp = gmdate("c");
    $passwordDigest = base64_encode(sha1($nonce . $timestamp . $secret, false));
    curl_setopt($ch,CURLOPT_HTTPHEADER, array("X-WSSE: UsernameToken ".
@@ -41,4 +41,3 @@ PHP
    curl_close($ch);
 
    echo $output;
-   ?>


### PR DESCRIPTION
According to [Microsoft WS-Security](https://msdn.microsoft.com/en-us/library/ms977327.aspx) the nonce should be 16 random bytes and base64_encode. Setting a fixed value is a security issue. If OpenSSL module is not installed try `mcrypt_create_iv()`. Also the PHP closing tag should be removed to [avoid problems](http://stackoverflow.com/questions/4410704/why-would-one-omit-the-close-tag) with extra lines and spaces.