### PR TITLE
Correct get data examples

### DIFF
--- a/source/suite/contacts/contact_data.rst
+++ b/source/suite/contacts/contact_data.rst
@@ -101,15 +101,16 @@ Error Condition:
          "errors":[
             {
                "key":"ironman@example.com",
-               "errorCode":"2008",
+               "errorCode":2008,
                "errorMsg":"No contact found with the external id: 3"
             },
             {
                "key":"hulk@example.com",
-               "errorCode":"2008",
+               "errorCode":2008,
                "errorMsg":"No contact found with the external id: 3"
             }
-         ]
+         ],
+         "result":false
       }
    }
 


### PR DESCRIPTION
During integration with the Suite Contacts API I discovered some minor things in the examples different than the actual API.

* Error Code is numeric
* the "result" is not omitted but set to false